### PR TITLE
LRQA-40521 Add 'max-iterations' attribute to 'while' element

### DIFF
--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -50,7 +50,7 @@ public class IfPoshiElement extends PoshiElement {
 			if (readableBlock.startsWith(getName() + " (")) {
 				add(
 					PoshiNodeFactory.newPoshiNode(
-						this, getParentheticalContent(readableBlock)));
+						this, getCondition(readableBlock)));
 
 				continue;
 			}
@@ -123,6 +123,10 @@ public class IfPoshiElement extends PoshiElement {
 		}
 
 		return sb.toString();
+	}
+
+	protected String getCondition(String readableSyntax) {
+		return getParentheticalContent(readableSyntax);
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/WhilePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/WhilePoshiElement.java
@@ -53,6 +53,28 @@ public class WhilePoshiElement extends IfPoshiElement {
 	}
 
 	@Override
+	protected String getBlockName() {
+		String parentheticalContent = getParentheticalContent(
+			super.getBlockName());
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(getReadableName());
+		sb.append(" (");
+		sb.append(parentheticalContent);
+
+		if (attributeValue("max-iterations") != null) {
+			sb.append(" && (maxIterations = \"");
+			sb.append(attributeValue("max-iterations"));
+			sb.append("\")");
+		}
+
+		sb.append(")");
+
+		return sb.toString();
+	}
+
+	@Override
 	protected String getCondition(String readableSyntax) {
 		String parentheticalContent = getParentheticalContent(readableSyntax);
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/WhilePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/WhilePoshiElement.java
@@ -52,6 +52,31 @@ public class WhilePoshiElement extends IfPoshiElement {
 		super(_ELEMENT_NAME, readableSyntax);
 	}
 
+	@Override
+	protected String getCondition(String readableSyntax) {
+		String parentheticalContent = getParentheticalContent(readableSyntax);
+
+		if (parentheticalContent.contains("&& (maxIterations = ")) {
+			int index = parentheticalContent.lastIndexOf("&&");
+
+			String maxIterationsAssignment = parentheticalContent.substring(
+				index + 2);
+
+			maxIterationsAssignment = getParentheticalContent(
+				maxIterationsAssignment);
+
+			String maxIterationsValue = getValueFromAssignment(
+				maxIterationsAssignment);
+
+			addAttribute(
+				"max-iterations", getQuotedContent(maxIterationsValue));
+
+			parentheticalContent = parentheticalContent.substring(0, index);
+		}
+
+		return parentheticalContent.trim();
+	}
+
 	private boolean _isElementType(String readableSyntax) {
 		readableSyntax = readableSyntax.trim();
 

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -250,6 +250,13 @@
 			</then>
 		</while>
 
+		<while max-iterations="16">
+			<condition function="IsElementPresent" locator1="AssetCategorization#TAGS_REMOVE_ICON_GENERIC" />
+			<then>
+				<execute function="Click" locator1="AssetCategorization#TAGS_REMOVE_ICON_GENERIC" />
+			</then>
+		</while>
+
 		<execute macro="Smoke#runSmoke" />
 
 		<execute function="AssertElementPresent" locator1="Home#PAGE" value1="Welcome" />

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -193,6 +193,10 @@ definition {
 			Click(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC");
 		}
 
+		while (IsElementPresent(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC") && (maxIterations = "16")) {
+			Click(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC");
+		}
+
 		Smoke.runSmoke();
 
 		AssertElementPresent(locator1 = "Home#PAGE", value1 = "Welcome");


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40521

Pull request tested here: https://github.com/pyoo47/com-liferay-poshi-runner/pull/40 (PASSED)

### Translation Status
#### At head: 
* 2322 / 2331 (99%) test commands were successfully translated
* 346 / 351 (98%) test files were successfully translated accounting for  2309 / 2331 (99%) test commands

#### With these changes:
* 2323 / 2331 (99%) test commands were successfully translated
* 347 / 351 (98%) test files were successfully translated accounting for  2311 / 2331 (99%) test commands

#### With these changes + https://github.com/brianchiu/liferay-portal/pull/1616: 
* 2331 / 2331 (100%) test commands were successfully translated
* 351 / 351 (100%) test files were successfully translated accounting for  2331 / 2331 (100%) test commands

### Changes in this pull include:
* Add support for 'max-iterations' attribute for 'while' elements. 
