### PR TITLE
LRQA-47047 Suppress SF on some files until auto sf avoids formatting strings in quotes

### DIFF
--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -3,6 +3,8 @@
 <suppressions>
 	<source-check>
 		<suppress checks="JavaMultiPlusConcatCheck" files=".*" />
+		<suppress checks="JavaStylingCheck" files="poshi-runner/src/test/java/com/liferay/poshi/runner/pql/PQLEntityFactoryTest\.java" />
+		<suppress checks="JavaStylingCheck" files="poshi-runner/src/test/java/com/liferay/poshi/runner/pql/PQLQueryTest\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files=".*" />
 	</source-check>
 </suppressions>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41047

After talking with @petershin, he said that we can temporarily add a source-formatter suppression file. Once he submits a fix to Hugo we can remove our suppression.