### PR TITLE
LRQA-41233 Poshiscript bug fix: 'static var' syntax for 'var method' calls is parsed as an 'execute macro'

### DIFF
--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -541,9 +541,8 @@ public class PoshiRunnerContext {
 			List<List<String>> partitions = Lists.partition(
 				classCommandNameGroup, groupSize);
 
-			for (int j = 0; j < partitions.size(); j++) {
-				classCommandNameGroups.put(
-					classCommandNameIndex, partitions.get(j));
+			for (List<String> partition : partitions) {
+				classCommandNameGroups.put(classCommandNameIndex, partition);
 
 				classCommandNameIndex++;
 			}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -352,16 +352,6 @@ public class PoshiRunnerContext {
 		return properties;
 	}
 
-	private static List<String> _getCommandReturns(Element commandElement) {
-		String returns = commandElement.attributeValue("returns");
-
-		if (returns == null) {
-			return new ArrayList<>();
-		}
-
-		return Arrays.asList(StringUtil.split(returns));
-	}
-
 	private static String _getCommandSummary(
 		String classCommandName, String classType, Element commandElement,
 		Element rootElement) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -377,7 +377,9 @@ public class ExecutePoshiElement extends PoshiElement {
 			return true;
 		}
 
-		if (readableSyntax.startsWith("var ")) {
+		if (readableSyntax.startsWith("static var ") ||
+			readableSyntax.startsWith("var")) {
+
 			return false;
 		}
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/LoggerElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/LoggerElement.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 /**
  * @author Michael Hashimoto
@@ -188,24 +189,11 @@ public class LoggerElement {
 	}
 
 	public void removeClassName(String className) {
-		String[] classNames = StringUtil.split(_className, " ");
+		String cleanedClassName = className.replaceFirst(
+			"(.*?)\\s*" + Matcher.quoteReplacement(className) + "\\s*(.*)",
+			"$1 $2");
 
-		StringBuilder sb = new StringBuilder();
-
-		for (int i = 0; i < classNames.length; i++) {
-			if (Validator.isNull(classNames[i])) {
-				continue;
-			}
-
-			if (Objects.equals(classNames[i], className)) {
-				continue;
-			}
-
-			sb.append(classNames[i]);
-			sb.append(" ");
-		}
-
-		setClassName(sb.toString());
+		setClassName(cleanedClassName.trim());
 	}
 
 	public void setAttribute(String attributeName, String attributeValue) {
@@ -327,20 +315,7 @@ public class LoggerElement {
 
 		Arrays.sort(classNames);
 
-		StringBuilder sb = new StringBuilder();
-
-		for (int i = 0; i < classNames.length; i++) {
-			if (Validator.isNull(classNames[i])) {
-				continue;
-			}
-
-			sb.append(classNames[i]);
-			sb.append(" ");
-		}
-
-		className = sb.toString();
-
-		return className.trim();
+		return StringUtil.join(classNames, " ");
 	}
 
 	private static final Set<String> _usedIds = new HashSet<>();

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil.java
@@ -347,6 +347,24 @@ public class StringUtil {
 		return true;
 	}
 
+	public static String join(String[] array, String delimiter) {
+		StringBuilder sb = new StringBuilder();
+
+		boolean start = true;
+
+		for (String string : array) {
+			if (!start) {
+				sb.append(delimiter);
+			}
+
+			sb.append(string);
+
+			start = false;
+		}
+
+		return sb.toString();
+	}
+
 	public static int length(String s) {
 		return s.length();
 	}

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/FormattedReadableSyntax.macro
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/FormattedReadableSyntax.macro
@@ -8,7 +8,7 @@ definition {
 	@prose = "I assert the ${breadcrumbName}"
 	macro viewPG {
 		var key_breadcrumbName = "${breadcrumbName}";
-		var breadcrumbNameUppercase = StringUtil.upperCase('${breadcrumbName}');
+		static var breadcrumbNameUppercase = StringUtil.upperCase('${breadcrumbName}');
 
 		AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
 

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/PoshiSyntax.macro
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/PoshiSyntax.macro
@@ -6,7 +6,7 @@
 	<command name="viewPG" prose="I assert the ${breadcrumbName}">
 		<var name="key_breadcrumbName" value="${breadcrumbName}" />
 
-		<var method="StringUtil#upperCase('${breadcrumbName}')" name="breadcrumbNameUppercase" />
+		<var method="StringUtil#upperCase('${breadcrumbName}')" static="true" name="breadcrumbNameUppercase" />
 
 		<execute function="AssertTextEquals" locator1="Breadcrumb#BREADCRUMB_ENTRY" value1="${breadcrumbNameUppercase}" />
 

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/ReadableSyntax.macro
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/ReadableSyntax.macro
@@ -6,7 +6,7 @@ definition {
 	@prose = "I assert the ${breadcrumbName}"
 	macro viewPG {
 		var key_breadcrumbName = "${breadcrumbName}";
-		var breadcrumbNameUppercase = StringUtil.upperCase('${breadcrumbName}');
+		static var breadcrumbNameUppercase = StringUtil.upperCase('${breadcrumbName}');
 
 		AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41233

Pull request tested here: https://github.com/pyoo47/com-liferay-poshi-runner/pull/81 (PASSED)

Please publish after merging