### PR TITLE
LRQA-44401 Poshi property 'test.include.dir.names' should not be required

### DIFF
--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunner.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunner.java
@@ -69,9 +69,13 @@ public class PoshiRunner {
 
 		List<String> baseDirNames = new ArrayList<>();
 
-		for (String testIncludeDirName : PropsValues.TEST_INCLUDE_DIR_NAMES) {
-			baseDirNames.add(
-				PoshiRunnerGetterUtil.getCanonicalPath(testIncludeDirName));
+		if (Validator.isNotNull(PropsValues.TEST_INCLUDE_DIR_NAMES)) {
+			for (String testIncludeDirName :
+					PropsValues.TEST_INCLUDE_DIR_NAMES) {
+
+				baseDirNames.add(
+					PoshiRunnerGetterUtil.getCanonicalPath(testIncludeDirName));
+			}
 		}
 
 		baseDirNames.add(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-44401

Pull request tested here: https://github.com/pyoo47/com-liferay-poshi-runner/pull/219 (PASSED)